### PR TITLE
Добавлен метод нормализации адреса из API отправки

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require": {
         "php": ">=7.1",
         "ext-soap": "*",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3",
+        "jms/serializer": "^1.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",

--- a/src/Dispatching/Address/Address.php
+++ b/src/Dispatching/Address/Address.php
@@ -16,8 +16,13 @@ class Address implements AddressInterface
 
     public function __construct(string $address, ?string $id = null)
     {
-        if (!$this->isAddressValid($address)) throw AddressException::incorrectAddress();
-        if (empty($id)) $id = $this->generateId($address);
+        if (!$this->isAddressValid($address)) {
+            throw AddressException::incorrectAddress();
+        }
+
+        if (empty($id)) {
+            $id = $this->generateId($address);
+        }
 
         $this->setAddress($address);
         $this->setId($id);

--- a/src/Dispatching/Address/Address.php
+++ b/src/Dispatching/Address/Address.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwilio\RussianPostSDK\Dispatching\Address;
+
+use Appwilio\RussianPostSDK\Dispatching\Exceptions\AddressException;
+
+class Address implements AddressInterface
+{
+    /** @var string */
+    private $id;
+
+    /** @var string */
+    private $address;
+
+    public function __construct(string $address, ?string $id = null)
+    {
+        if (!$this->isAddressValid($address)) throw AddressException::incorrectAddress();
+        if (empty($id)) $id = $this->generateId($address);
+
+        $this->setAddress($address);
+        $this->setId($id);
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function setAddress(string $address)
+    {
+        $this->address = $address;
+    }
+
+    private function isAddressValid(string $address): bool
+    {
+        $address = trim($address);
+        return (bool)(!empty($address));
+    }
+
+    private function generateId(string $string): string
+    {
+        return sha1($string);
+    }
+}

--- a/src/Dispatching/Address/AddressInterface.php
+++ b/src/Dispatching/Address/AddressInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Appwilio\RussianPostSDK\Dispatching\Address;
+
+interface AddressInterface
+{
+    public function setAddress(string $address);
+
+    public function setId(string $id);
+
+    public function getAddress(): string;
+
+    public function getId(): string;
+}

--- a/src/Dispatching/Client.php
+++ b/src/Dispatching/Client.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Appwilio\RussianPostSDK\Dispatching;
 
 use Appwilio\RussianPostSDK\Dispatching\Address\Address;
-use Appwilio\RussianPostSDK\Dispatching\Requests\apiClient;
+use Appwilio\RussianPostSDK\Dispatching\Requests\ApiClient;
 use Appwilio\RussianPostSDK\Dispatching\Requests\AuthorizationHeader;
 use Appwilio\RussianPostSDK\Dispatching\Requests\CleanAddressRequest;
 use Appwilio\RussianPostSDK\Dispatching\Responses\CleanAddressCollectionResponse;
@@ -23,10 +23,13 @@ class Client
 {
     protected const API_URL = 'https://otpravka-api.pochta.ru/1.0/';
 
+    /** @var ApiClient */
+    private $client;
 
     public function __construct(string $login, string $password, string $token)
     {
-        $this->auth = new AuthorizationHeader($login, $password, $token);
+        $auth = new AuthorizationHeader($login, $password, $token);
+        $this->client = new ApiClient($auth);
     }
 
     /**
@@ -43,9 +46,7 @@ class Client
         $cleanAddressRequest = new CleanAddressRequest();
         $cleanAddressRequest->addAddress(new Address($address, $id));
 
-        $apiClient = new apiClient($this->auth);
-
-        $response = $apiClient->send($cleanAddressRequest);
+        $response = $this->client->send($cleanAddressRequest);
 
         return $response;
     }

--- a/src/Dispatching/Client.php
+++ b/src/Dispatching/Client.php
@@ -13,37 +13,41 @@ declare(strict_types=1);
 
 namespace Appwilio\RussianPostSDK\Dispatching;
 
-use GuzzleHttp\Client as GuzzleClient;
+use Appwilio\RussianPostSDK\Dispatching\Address\Address;
+use Appwilio\RussianPostSDK\Dispatching\Requests\apiClient;
+use Appwilio\RussianPostSDK\Dispatching\Requests\AuthorizationHeader;
+use Appwilio\RussianPostSDK\Dispatching\Requests\CleanAddressRequest;
+use Appwilio\RussianPostSDK\Dispatching\Responses\CleanAddressCollectionResponse;
 
 class Client
 {
     protected const API_URL = 'https://otpravka-api.pochta.ru/1.0/';
 
-    /** @var string */
-    private $login;
-
-    /** @var string */
-    private $password;
-
-    /** @var string */
-    private $token;
-
-    /** @var GuzzleClient */
-    private $httpClient;
 
     public function __construct(string $login, string $password, string $token)
     {
-        $this->login = $login;
-        $this->password = $password;
-        $this->token = $token;
+        $this->auth = new AuthorizationHeader($login, $password, $token);
     }
 
-    protected function getHttpClient(): GuzzleClient
+    /**
+     * @param string $address
+     * @param null|string $id
+     * @return CleanAddressCollectionResponse
+     * @throws Exceptions\AddressException
+     */
+    public function getCleanAddress(
+        string $address,
+        ?string $id = null
+    ): CleanAddressCollectionResponse
     {
-        if (! $this->httpClient) {
-            $this->httpClient = new GuzzleClient();
-        }
+        $cleanAddressRequest = new CleanAddressRequest();
+        $cleanAddressRequest->addAddress(new Address($address, $id));
 
-        return $this->httpClient;
+        $apiClient = new apiClient($this->auth);
+
+        $response = $apiClient->send($cleanAddressRequest);
+
+        return $response;
     }
+
 }

--- a/src/Dispatching/Exceptions/AddressException.php
+++ b/src/Dispatching/Exceptions/AddressException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwilio\RussianPostSDK\Dispatching\Exceptions;
+
+class AddressException extends \Exception
+{
+    public static function unknownAddressException(): self
+    {
+        return new self('Неизвестная ошибка в адресе', 450100);
+    }
+
+    public static function incorrectAddress(): self
+    {
+        return new self('Указан некорректный или пустой адрес', 450101);
+    }
+
+    public static function addressDoesntExist(): self
+    {
+        return new self('Адрес с таким id не существует', 450102);
+    }
+
+
+}

--- a/src/Dispatching/Requests/AuthorizationHeader.php
+++ b/src/Dispatching/Requests/AuthorizationHeader.php
@@ -7,23 +7,28 @@ namespace Appwilio\RussianPostSDK\Dispatching\Requests;
 class AuthorizationHeader
 {
     /** @var string */
-    public $login;
-
-    /** @var string */
-    public $password;
+    public $basicAuth;
 
     /** @var string */
     public $token;
 
-    public function __construct(?string $login = null, ?string $password = null, ?string $token = null)
+    public function __construct(string $login, string $password, string $token)
     {
-        $this->login = $login;
-        $this->password = $password;
+        $this->basicAuth = $this->basicAuth($login, $password);
         $this->token = $token;
     }
 
-    public function basicAuth(): string
+    public function basicAuth(string $login, string $password): string
     {
-        return base64_encode($this->login . ":" . $this->password);
+        return base64_encode($login . ":" . $password);
+    }
+
+    public function buildHeaders(): array
+    {
+        return
+            [
+                'Authorization'        => 'AccessToken ' . $this->token,
+                'X-User-Authorization' => 'Basic ' . $this->basicAuth
+            ];
     }
 }

--- a/src/Dispatching/Requests/AuthorizationHeader.php
+++ b/src/Dispatching/Requests/AuthorizationHeader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwilio\RussianPostSDK\Dispatching\Requests;
+
+class AuthorizationHeader
+{
+    /** @var string */
+    public $login;
+
+    /** @var string */
+    public $password;
+
+    /** @var string */
+    public $token;
+
+    public function __construct(?string $login = null, ?string $password = null, ?string $token = null)
+    {
+        $this->login = $login;
+        $this->password = $password;
+        $this->token = $token;
+    }
+
+    public function basicAuth(): string
+    {
+        return base64_encode($this->login . ":" . $this->password);
+    }
+}

--- a/src/Dispatching/Requests/CleanAddressRequest.php
+++ b/src/Dispatching/Requests/CleanAddressRequest.php
@@ -2,25 +2,39 @@
 
 namespace Appwilio\RussianPostSDK\Dispatching\Requests;
 
-class CleanAddressRequest
+use Appwilio\RussianPostSDK\Dispatching\Address\AddressInterface;
+
+class CleanAddressRequest implements RequestInterface
 {
     public const ENDPOINT = 'https://otpravka-api.pochta.ru/1.0/clean/address';
+    public const METHOD = 'POST';
 
-    /** @var string */
-    private $address;
+    /** @var array */
+    private $addresses = [];
 
-    public function __construct(iterable $address)
+    public function getUrl(): string
     {
-        $this->address = $address;
+        return self::ENDPOINT;
     }
 
-    public function getAddress(): string
+    public function getMethod(): string
     {
-        return $this->address;
+        return self::METHOD;
     }
 
-    public function getId(): string
+    public function getBodyArray(): array
     {
-        return sha1($this->address);
+        return $this->addresses;
     }
+
+
+    public function addAddress(AddressInterface $address)
+    {
+        $this->addresses[] = [
+            "id"               => $address->getId(),
+            "original-address" => $address->getAddress()
+        ];
+    }
+
+
 }

--- a/src/Dispatching/Requests/RequestInterface.php
+++ b/src/Dispatching/Requests/RequestInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Appwilio\RussianPostSDK\Dispatching\Requests;
+
+interface RequestInterface
+{
+    public function getUrl(): string;
+
+    public function getBodyArray(): array;
+
+    public function getMethod(): string;
+}

--- a/src/Dispatching/Requests/apiClient.php
+++ b/src/Dispatching/Requests/apiClient.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Appwilio\RussianPostSDK\Dispatching\Requests;
+
+use GuzzleHttp\Client as GuzzleClient;
+use Appwilio\RussianPostSDK\Dispatching\Responses\CalculateResponse;
+use Appwilio\RussianPostSDK\Dispatching\Responses\CleanAddressCollectionResponse;
+use Appwilio\RussianPostSDK\Dispatching\Responses\CleanPhoneResponse;
+use JMS\Serializer\SerializerBuilder;
+
+class apiClient
+{
+    /** @var string */
+    private $auth;
+
+    /** @var GuzzleClient */
+    private $httpClient;
+
+    protected $map = [
+        CleanAddressRequest::class => CleanAddressCollectionResponse::class,
+        CleanPhoneRequest::class   => CleanPhoneResponse::class,
+        CalculateRequest::class    => CalculateResponse::class,
+    ];
+
+    public function __construct(AuthorizationHeader $authorizationHeader)
+    {
+       $this->auth = $authorizationHeader;
+    }
+
+    protected function getHttpClient(): GuzzleClient
+    {
+        if (!$this->httpClient) {
+            $this->httpClient = new GuzzleClient([
+                'headers' => [
+                    'Authorization'        => 'AccessToken ' . $this->auth->token,
+                    'Content-Type'         => 'application/json',
+                    'Accept'               => 'application/json;charset=UTF-8',
+                    'X-User-Authorization' => 'Basic ' . $this->auth->basicAuth(),
+                ]
+            ]);
+        }
+        return $this->httpClient;
+    }
+
+    public function send(RequestInterface $request)
+    {
+        $response = ($this->getHttpClient())->request(
+            $request->getMethod(),
+            $request->getUrl(),
+            [
+                'body'   => json_encode($request->getBodyArray()),
+                'stream' => true
+            ]
+        );
+
+        $stream = $response->getBody();
+        $result = "";
+        while (!$stream->eof()) {
+            $result .= $stream->read(1024);
+        }
+
+        //Sometimes $result is unnamed collection
+        //Need to wrap up result in to "body" for correct deserialization
+        $result = '{ "body": '.(string)$result.' }';
+
+        $serializer = SerializerBuilder::create()->build();
+        return $serializer->deserialize($result, $this->map[get_class($request)], 'json');
+    }
+
+}

--- a/src/Dispatching/Responses/CleanAddress.php
+++ b/src/Dispatching/Responses/CleanAddress.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Appwilio\RussianPostSDK\Dispatching\Responses;
+
+use JMS\Serializer\Annotation AS JMS;
+
+class CleanAddress
+{
+
+    /**
+     * @JMS\Type("string")
+     * @JMS\SerializedName("address-type")
+     *
+     */
+    public $address_type;
+
+    /**
+     * @JMS\Type("string")
+     */
+    public $id;
+
+    /**
+     * @JMS\Type("string")
+     */
+    public $index;
+
+    /**
+     * @JMS\Type("string")
+     * @JMS\SerializedName("original-address")
+     */
+    public $original_address;
+
+    /**
+     * @JMS\Type("string")
+     */
+    public $place;
+
+    /**
+     * @JMS\Type("string")
+     * @JMS\SerializedName("quality-code")
+     */
+    public $quality_code;
+
+    /**
+     * @JMS\Type("string")
+     */
+    public $region;
+
+    /**
+     * @JMS\Type("string")
+     */
+    public $street;
+
+    /**
+     * @JMS\Type("string")
+     */
+    public $house;
+
+    /**
+     * @JMS\Type("string")
+     * @JMS\SerializedName("validation-code")
+     */
+    public $validation_code;
+
+}

--- a/src/Dispatching/Responses/CleanAddressCollectionResponse.php
+++ b/src/Dispatching/Responses/CleanAddressCollectionResponse.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Appwilio\RussianPostSDK\Dispatching\Responses;
+
+use JMS\Serializer\Annotation AS JMS;
+
+class CleanAddressCollectionResponse
+{
+
+    /**
+     * @JMS\Type("array<Appwilio\RussianPostSDK\Dispatching\Responses\CleanAddress>")
+     * @JMS\SerializedName("body")
+     */
+    public $addresses = [];
+
+}


### PR DESCRIPTION
### Пометки
* В composer.json для десериализации json добавил jms/serializer 
* Для запросов добавил RequestInterface
* Guzzle клиент отказывался корректно скачивать сразу весь ответ, пришлось явно указать stream = true и скачивать по частям (возможно решить в будущем)