### PR TITLE
Correct hours format is 24-H instead 12-h

### DIFF
--- a/src/Tracking/Packet/ItemsWrapper.php
+++ b/src/Tracking/Packet/ItemsWrapper.php
@@ -39,7 +39,7 @@ final class ItemsWrapper
     public function getPreparedAt(): \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromFormat(
-            'd.m.Y h:i:s',
+            'd.m.Y H:i:s',
             $this->DatePreparation,
             new \DateTimeZone('Europe/Moscow')
         );


### PR DESCRIPTION
Иначе валится с ошибкой строка из примера $response->getPreparedAt() в случаях, когда событие произошло после полудня