### PR TITLE
CashOnDeliveryWrapper: single event bugfix

### DIFF
--- a/src/Tracking/Single/CashOnDeliveryEventsWrapper.php
+++ b/src/Tracking/Single/CashOnDeliveryEventsWrapper.php
@@ -23,6 +23,6 @@ final class CashOnDeliveryEventsWrapper
      */
     public function getEvents(): array
     {
-        return $this->PostalOrderEvent;
+        return $this->PostalOrderEvent instanceof CashOnDeliveryEvent ? [$this->PostalOrderEvent] : $this->PostalOrderEvent;
     }
 }


### PR DESCRIPTION
When API provides only one item, then the $this->PostalOrderEvent is not and array.