### PR TITLE
Be able to run on Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-soap": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0.1",
         "psr/log": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 8 requires Guzzle ^7.0.1 to run, while this package locked on version 6.

https://laravel.com/docs/8.x/upgrade