### PR TITLE
Совместимость с Laravel 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4]
         stability: [prefer-lowest, prefer-stable]
     
     name: PHP ${{ matrix.php }} / ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-soap": "*",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.2",
         "psr/log": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-soap": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0",
         "psr/log": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "issues": "https://github.com/appwilio/russianpost-sdk/issues"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-soap": "*",

--- a/src/Dispatching/Http/ApiClient.php
+++ b/src/Dispatching/Http/ApiClient.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Appwilio\RussianPostSDK\Dispatching\Http;
 
-use GuzzleHttp\Psr7\Utils;
-use GuzzleHttp\Psr7\Query;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
+use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\UploadedFile;

--- a/src/Dispatching/Http/ApiClient.php
+++ b/src/Dispatching/Http/ApiClient.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Appwilio\RussianPostSDK\Dispatching\Http;
 
+use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Psr7\Query;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
@@ -30,9 +32,6 @@ use Appwilio\RussianPostSDK\Dispatching\Exceptions\ServerFault;
 use Appwilio\RussianPostSDK\Dispatching\Contracts\DispatchingException;
 use function GuzzleHttp\json_encode as guzzle_json_encode;
 use function GuzzleHttp\json_decode as guzzle_json_decode;
-use function GuzzleHttp\Psr7\stream_for as guzzle_stream_for;
-use function GuzzleHttp\Psr7\build_query as guzzle_build_query;
-use function GuzzleHttp\Psr7\modify_request as guzzle_modify_request;
 
 final class ApiClient implements LoggerAwareInterface
 {
@@ -137,12 +136,12 @@ final class ApiClient implements LoggerAwareInterface
         $this->logger->info("Dispatching request: {$path}", $data);
 
         if ($method === 'GET') {
-            return guzzle_modify_request($request, ['query' => guzzle_build_query($data)]);
+            return Utils::modifyRequest($request, ['query' => Query::build($data)]);
         }
 
         return $request
             ->withHeader('Content-Type', 'application/json;charset=UTF-8')
-            ->withBody(guzzle_stream_for(guzzle_json_encode($data)));
+            ->withBody(Utils::streamFor((guzzle_json_encode($data))));
     }
 
     private function serializeRequestData(array $data): array

--- a/tests/Dispatching/Http/ApiClientTest.php
+++ b/tests/Dispatching/Http/ApiClientTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Appwilio\RussianPostSDK\Tests\Dispatching\Http;
 
 use Psr\Log\NullLogger;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\UploadedFile;
@@ -29,7 +30,6 @@ use Appwilio\RussianPostSDK\Dispatching\Http\Authentication;
 use Appwilio\RussianPostSDK\Dispatching\Exceptions\BadRequest;
 use Appwilio\RussianPostSDK\Dispatching\Exceptions\ServerFault;
 use function GuzzleHttp\json_encode as guzzle_json_encode;
-use function GuzzleHttp\Psr7\stream_for as guzzle_stream_for;
 
 class ApiClientTest extends TestCase
 {
@@ -75,7 +75,7 @@ class ApiClientTest extends TestCase
         /** @var UploadedFile $response */
         $response = $this->createClient(
             $contentType = 'application/pdf',
-            guzzle_stream_for($tmp),
+            Utils::streamFor($tmp),
             ['Content-Disposition' => 'attachment; filename=foo']
         )->get('foo');
 


### PR DESCRIPTION
Не можем обновить Laravel до 8 версии т.к. конфликт в версиях guzzlehttp/guzzle.

Laravel 8 хочет: ^7.0
Пакет использует: ^6.3